### PR TITLE
Storage responses

### DIFF
--- a/src/main/java/dream/fcard/logic/storage/StorageManager.java
+++ b/src/main/java/dream/fcard/logic/storage/StorageManager.java
@@ -78,6 +78,14 @@ public class StorageManager {
     }
 
     /**
+     * Returns value of current root.
+     * @return  root directory
+     */
+    public static String getRoot() {
+        return root;
+    }
+
+    /**
      * Write a deck into decks storage.
      * @param deck  deck object to write
      */
@@ -94,7 +102,7 @@ public class StorageManager {
     public static ArrayList<Deck> loadDecks() {
         resolveRoot();
         String path = FileReadWrite.resolve(root, decksSubDir);
-        System.out.println(path);
+
         if (!FileReadWrite.fileExists(path)) {
             return new ArrayList<>();
         }
@@ -115,7 +123,7 @@ public class StorageManager {
      * @param filePath  Must be valid existing filepath to a deck json file.
      * @return          deck object
      */
-    private static Deck loadDeck(String filePath) {
+    public static Deck loadDeck(String filePath) {
         try {
             return parseDeckJsonFile(FileReadWrite.read(filePath));
         } catch (FileNotFoundException e) {

--- a/src/main/java/dream/fcard/model/State.java
+++ b/src/main/java/dream/fcard/model/State.java
@@ -35,6 +35,14 @@ public class State {
     }
 
     /**
+     * Adds a deck object to decks list.
+     * @param deck  deck object
+     */
+    public void addDeck(Deck deck) {
+        decks.add(deck);
+    }
+
+    /**
      * Removes the deck from the decks list, if there is a deck with a matching name.
      * Else, throw exception when no deck with matching name is found.
      */
@@ -58,6 +66,14 @@ public class State {
             throw new DeckNotFoundException("Deck not found - " + name);
         }
         return decks.get(indexOfDeck);
+    }
+
+    /**
+     * Replace all decks with a new set of decks. Used by `root` command.
+     * @param newDecks  new decks
+     */
+    public void reloadAllDecks(ArrayList<Deck> newDecks) {
+        decks = newDecks;
     }
 
     /**

--- a/src/main/java/dream/fcard/util/FileReadWrite.java
+++ b/src/main/java/dream/fcard/util/FileReadWrite.java
@@ -110,4 +110,23 @@ public class FileReadWrite {
         File file = new File(normalizePath(path));
         return file.exists();
     }
+
+    /**
+     * Determine if path is a valid directory.
+     * @param path  path to directory
+     * @return      true if valid directory
+     */
+    public static Boolean pathValidDirectory(String path) {
+        File file = new File(normalizePath(path));
+        return file.exists() && file.isDirectory();
+    }
+
+    /**
+     * Given a path to a file, extract the file name.
+     * @param path  path to file
+     * @return      name of file
+     */
+    public static String getFileName(String path) {
+        return new File(normalizePath(path)).getName();
+    }
 }

--- a/src/test/java/dream/fcard/logic/respond/ResponsesTest.java
+++ b/src/test/java/dream/fcard/logic/respond/ResponsesTest.java
@@ -1,0 +1,123 @@
+package dream.fcard.logic.respond;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+
+import org.junit.jupiter.api.Test;
+
+import dream.fcard.logic.storage.StorageManager;
+import dream.fcard.model.Deck;
+import dream.fcard.model.State;
+import dream.fcard.model.cards.FrontBackCard;
+import dream.fcard.model.exceptions.DeckNotFoundException;
+import dream.fcard.util.FileReadWrite;
+
+public class ResponsesTest {
+    @Test
+    void rootTest() {
+        String path = FileReadWrite.resolve("./", "./testDir");
+        new File(path).mkdirs();
+        // make directory for testing
+
+        Responses.ROOT.call("root " + path, new State());
+        assertEquals(path, StorageManager.getRoot());
+        // test
+
+        FileReadWrite.delete(path);
+        // cleanup
+    }
+
+    @Test
+    void rootNoPathTest() {
+        assertEquals(true, Responses.ROOT_NO_PATH.call("root", new State()));
+    }
+
+    @Test
+    void importTest() {
+        String deckName = "test123";
+        String path = FileReadWrite.normalizePath("~/" + deckName + ".json");
+        String root = FileReadWrite.normalizePath("~/testDir");
+        // test parameters
+
+        StorageManager.provideRoot(root);
+
+        State s = new State();
+        Deck d = new Deck(deckName);
+        d.addNewCard(new FrontBackCard("front", "back"));
+        // create stubs
+
+        FileReadWrite.write(path, d.toJson().toString());
+        // create file
+
+        Responses.IMPORT.call("import " + path, s);
+        // test import
+
+        try {
+            assertEquals(deckName, s.getDeck(deckName).getName());
+            assertEquals(d.toJson().toString(), s.getDeck(deckName).toJson().toString());
+        } catch (DeckNotFoundException e) {
+            fail();
+        }
+        // check deck valid
+
+        FileReadWrite.delete(path);
+        FileReadWrite.delete(FileReadWrite.resolve(root, "./decks/" + deckName + ".json"));
+        FileReadWrite.delete(FileReadWrite.resolve(root, "./decks"));
+        FileReadWrite.delete(root);
+        // cleanup
+    }
+
+    @Test
+    void importNoPathTest() {
+        assertEquals(true, Responses.IMPORT_NO_PATH.call("import", new State()));
+    }
+
+    @Test
+    void exportTest() {
+        String deckName = "test123";
+        String path = FileReadWrite.normalizePath("~");
+        String exportPath = FileReadWrite.resolve(path, "./" + deckName + ".json");
+        String root = FileReadWrite.normalizePath("~/testDir");
+        // test parameters
+
+        StorageManager.provideRoot(root);
+
+        State s = new State();
+        Deck d = new Deck(deckName);
+        d.addNewCard(new FrontBackCard("front", "back"));
+        s.addDeck(d);
+        // create stubs
+
+        StorageManager.writeDeck(d);
+        // store in root
+
+        Responses.EXPORT.call("export deck/ " + deckName + " path/ " + path, s);
+        // test export
+
+        try {
+            assertEquals(d.toJson().toString(), FileReadWrite.read(exportPath));
+        } catch (FileNotFoundException e) {
+            fail();
+        }
+        // check export valid
+
+        FileReadWrite.delete(exportPath);
+        FileReadWrite.delete(FileReadWrite.resolve(root, "./decks/" + deckName + ".json"));
+        FileReadWrite.delete(FileReadWrite.resolve(root, "./decks"));
+        FileReadWrite.delete(root);
+        // cleanup
+    }
+
+    @Test
+    void exportNoPathTest() {
+        assertEquals(true, Responses.EXPORT_NO_PATH.call("export deck/ test", new State()));
+    }
+
+    @Test
+    void exportNoDeckTest() {
+        assertEquals(true, Responses.EXPORT_NO_DECK.call("export", new State()));
+    }
+}


### PR DESCRIPTION
- I've modified the regex for import and export according to the example specified in `HELP` enum comments. @PhireHandy 
- The state now has a method to replace its array list of decks, used when the user changes the root directory.
- The state now has a method to add a new deck object to its list, used when import

close #90
close #91 
close #92